### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cursor MCP - Claude Desktop Integration
 
+[![smithery badge](https://smithery.ai/badge/cursor-mcp-tool)](https://smithery.ai/server/cursor-mcp-tool)
+
 A Model Context Protocol implementation for Claude Desktop using the MCP TypeScript SDK.
 
 ## Features


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/cursor-mcp-tool. This provides visibility into how many times the MCP has been installed.
2. Modifies formatting for better consistency and readability.

Let me know if any tweaks have to be made!