### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A Model Context Protocol implementation for Claude Desktop using the MCP TypeScript SDK.
 
+<a href="https://glama.ai/mcp/servers/4fg1gxbcex"><img width="380" height="200" src="https://glama.ai/mcp/servers/4fg1gxbcex/badge" alt="Cursor Server MCP server" /></a>
+
 ## Features
 @@ -40,4 +42,4 @@ cursor-mcp/
 - Follow TypeScript best practices


### PR DESCRIPTION
This PR adds a badge for the [Cursor MCP Server](https://glama.ai/mcp/servers/4fg1gxbcex) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/4fg1gxbcex"><img width="380" height="200" src="https://glama.ai/mcp/servers/4fg1gxbcex/badge" alt="Cursor Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.